### PR TITLE
Adding missing require for connectionpool

### DIFF
--- a/src/tourmaline/client.cr
+++ b/src/tourmaline/client.cr
@@ -12,6 +12,7 @@ require "./annotations"
 require "./filter"
 require "./event_handler"
 require "./client/*"
+require "pool/connection"
 
 module Tourmaline
   # The `Client` class is the base class for all Tourmaline based bots.


### PR DESCRIPTION
Adds a missing require needed to utilize `ConnectionPool` within `client.cr`

Without this change, running a `crystal build src/tourmaline.cr` would throw a reference error.

This `require` follows the [Getting Started section of the pool library](https://github.com/watzon/pool#getting-started).

All tests passing without error.