### PR TITLE
Fix wrong URL for API documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dependencies:
 
 ## Usage
 
-API documentation is also available [here](https://api.tourmaline.dev).
+API documentation is also available [here](https://tourmaline.dev/api_reference/Tourmaline/).
 
 Examples are available in the [examples](https://github.com/protoncr/tourmaline/branch/master/examples) folder.
 


### PR DESCRIPTION
The URL for the API documentation seems wrong, could the server hosting the docs not setup correctly to have to api subdomain pointing to the correct page here https://tourmaline.dev/api_reference/Tourmaline/? 