### PR TITLE
Add CallbackQuery with game_short_name can be processed

### DIFF
--- a/src/tourmaline/handlers/callback_query_handler.cr
+++ b/src/tourmaline/handlers/callback_query_handler.cr
@@ -12,7 +12,7 @@ module Tourmaline
 
       def call(client : Client, update : Update)
         if query = update.callback_query
-          data = query.data
+          data = query.data || query.game_short_name
           if data
             if match = data.match(@pattern)
               context = Context.new(update, query.message, query, match)


### PR DESCRIPTION
Hi!
 I was testing tourmaline for a possible replacement for my telegram api client and I really liked it. 
But the key functionality for me is the game callback answer unfortunately not implemented.

```crystal
require "tourmaline"
GAME_NAME = "my_game_name"

class TelegramBot < Tourmaline::Client
  @[OnCallbackQuery(GAME_NAME)]
  def process_query(ctx)
    game = ActiveGame.process_update(ctx.query)
    answer_callback_query(ctx.query.id, url: game.player_a_route.url)
  end
end
```
So the game callback is handled fine in my app.
Thanks you.
