### PR TITLE
Experimental support for Middleware

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-crystal 0.35.1
+crystal 0.36.1

--- a/src/tourmaline/client/core_methods.cr
+++ b/src/tourmaline/client/core_methods.cr
@@ -255,6 +255,15 @@ module Tourmaline
       # (current name of the user for one-on-one conversations,
       # current username of a user, group or channel, etc.).
       # Returns a `Chat` object on success.
+      #
+      # !!! tip
+      #     When using TDLight this method isn't restructed to chats/users your
+      #     bot is familiar with.
+      #
+      # !!! warning
+      #     When using TDLight this method will first check for a locally cached
+      #     chat, then use MTProto if that fails. When using MTProto this method
+      #     is __heavily__ rate limited, so be careful.
       def get_chat(chat)
         chat_id = chat.is_a?(Int::Primitive | String) ? chat : chat.id
 

--- a/src/tourmaline/handlers/callback_query_handler.cr
+++ b/src/tourmaline/handlers/callback_query_handler.cr
@@ -15,7 +15,7 @@ module Tourmaline
           data = query.data
           if data
             if match = data.match(@pattern)
-              context = Context.new(update, query.message, query, match)
+              context = Context.new(update, update.context, query.message, query, match)
               @proc.call(context)
               return true
             end
@@ -23,7 +23,12 @@ module Tourmaline
         end
       end
 
-      record Context, update : Update, message : Message?, query : CallbackQuery, match : Regex::MatchData
+      record Context,
+        update : Update,
+        context : Middleware::Context,
+        message : Message?,
+        query : CallbackQuery,
+        match : Regex::MatchData
     end
   end
 end

--- a/src/tourmaline/handlers/chosen_inline_result_handler.cr
+++ b/src/tourmaline/handlers/chosen_inline_result_handler.cr
@@ -16,13 +16,17 @@ module Tourmaline
           if query && (pattern = @pattern)
             match = query.match(pattern)
           end
-          context = Context.new(update, result, match)
+          context = Context.new(update, update.context, result, match)
           @proc.call(context)
           return true
         end
       end
 
-      record Context, update : Update, result : ChosenInlineResult, match : Regex::MatchData?
+      record Context,
+        update : Update,
+        context : Middleware::Context,
+        result : ChosenInlineResult,
+        match : Regex::MatchData?
     end
   end
 end

--- a/src/tourmaline/handlers/command_handler.cr
+++ b/src/tourmaline/handlers/command_handler.cr
@@ -105,14 +105,22 @@ module Tourmaline
             command = command.sub(prefix_re, "")
             return unless @commands.includes?(command)
 
-            context = Context.new(update, message, command, text, raw_text, !!botname, !!update.edited_message)
+            context = Context.new(update, update.context, message, command, text, raw_text, !!botname, !!update.edited_message)
             @proc.call(context)
             return true
           end
         end
       end
 
-      record Context, update : Update, message : Message, command : String, text : String, raw_text : String, botname : Bool, edit : Bool
+      record Context,
+        update : Update,
+        context : Middleware::Context,
+        message : Message,
+        command : String,
+        text : String,
+        raw_text : String,
+        botname : Bool,
+        edit : Bool
     end
   end
 end

--- a/src/tourmaline/handlers/edited_handler.cr
+++ b/src/tourmaline/handlers/edited_handler.cr
@@ -10,13 +10,13 @@ module Tourmaline
 
       def call(client : Client, update : Update)
         if message = update.edited_message || update.edited_channel_post
-          context = Context.new(update, message)
+          context = Context.new(update, update.context, message)
           @proc.call(context)
           return true
         end
       end
 
-      record Context, update : Update, message : Message
+      record Context, update : Update, context : Middleware::Context, message : Message
     end
   end
 end

--- a/src/tourmaline/handlers/hears_handler.cr
+++ b/src/tourmaline/handlers/hears_handler.cr
@@ -15,7 +15,7 @@ module Tourmaline
         if message = update.message || update.channel_post
           if (text = message.text) || (text = message.caption)
             if match = text.match(@pattern)
-              context = Context.new(update, message, text, match)
+              context = Context.new(update, update.context, message, text, match)
               @proc.call(context)
               return true
             end
@@ -23,7 +23,12 @@ module Tourmaline
         end
       end
 
-      record Context, update : Update, message : Message, text : String, match : Regex::MatchData
+      record Context,
+        update : Update,
+        context : Middleware::Context,
+        message : Message,
+        text : String,
+        match : Regex::MatchData
     end
   end
 end

--- a/src/tourmaline/handlers/inline_query_handler.cr
+++ b/src/tourmaline/handlers/inline_query_handler.cr
@@ -16,7 +16,7 @@ module Tourmaline
           data = query.query
           if data
             if match = data.match(@pattern)
-              context = Context.new(update, query, match)
+              context = Context.new(update, update.context, query, match)
               @proc.call(context)
               return true
             end
@@ -24,7 +24,11 @@ module Tourmaline
         end
       end
 
-      record Context, update : Update, query : InlineQuery, match : Regex::MatchData
+      record Context,
+        update : Update,
+        context : Middleware::Context,
+        query : InlineQuery,
+        match : Regex::MatchData
     end
   end
 end

--- a/src/tourmaline/middleware.cr
+++ b/src/tourmaline/middleware.cr
@@ -23,6 +23,11 @@ module Tourmaline
         @parameters[name.to_s]?.try &.value
       end
 
+      # Returns the value of the parameter with the provided *name* as a `type` if it exists, otherwise `nil`.
+      def get?(name, type : T.class) forall T
+        @parameters[name.to_s]?.try &.value.as(T)
+      end
+
       # Returns the value of the parameter with the provided *name*.
       #
       # Raises a `KeyError` if no parameter with that name exists.

--- a/src/tourmaline/middleware.cr
+++ b/src/tourmaline/middleware.cr
@@ -1,0 +1,54 @@
+module Tourmaline
+  alias MiddlewareProc = Proc(Client, Update, Nil)
+
+  module Middleware
+    abstract def call(client : Client, update : Update)
+
+    struct Context
+      private abstract struct Param
+        abstract def value
+      end
+
+      private record Parameter(T) < Param, value : T
+
+      @parameters : Hash(String, Param) = Hash(String, Param).new
+
+      # Returns `true` if a parameter with the provided *name* exists, otherwise `false`.
+      def has?(name) : Bool
+        @parameters.has_key? name.to_s
+      end
+
+      # Returns the value of the parameter with the provided *name* if it exists, otherwise `nil`.
+      def get?(name)
+        @parameters[name.to_s]?.try &.value
+      end
+
+      # Returns the value of the parameter with the provided *name*.
+      #
+      # Raises a `KeyError` if no parameter with that name exists.
+      def get(name)
+        @parameters.fetch(name.to_s) { raise KeyError.new "No parameter exists with the name '#{name.to_s}'." }.value
+      end
+
+      # Returns the value of the parameter with the provided *name* as a `type`.
+      def get(name, type : T.class) forall T
+        get(name).as(T)
+      end
+
+      # Sets a parameter with the provided *name* to *value*.
+      def set(name, value : T) : Nil forall T
+        self.set name.to_s, value, T
+      end
+
+      # Sets a parameter with the provided *name* to *value*, restricted to the given *type*.
+      def set(name, value : _, type : T.class) : Nil forall T
+        @parameters[name.to_s] = Parameter(T).new value
+      end
+
+      # Removes the parameter with the provided *name*.
+      def remove(name) : Nil
+        @parameters.delete name.to_s
+      end
+    end
+  end
+end

--- a/src/tourmaline/models/update.cr
+++ b/src/tourmaline/models/update.cr
@@ -50,6 +50,10 @@ module Tourmaline
     # votes only in polls that were sent by the bot itself.
     getter poll_answer : PollAnswer?
 
+    # Context object allowing data to be passed from middleware to handlers.
+    @[JSON::Field(ignore: true)]
+    getter context : Middleware::Context { Middleware::Context.new }
+
     # Returns all users included in this update as a Set
     def users
       users = [] of User?


### PR DESCRIPTION
This PR adds experimental support for Middleware objects. They get run sequentially on each update. In addition a `context` property has been added to `Update` which allows values to be added and removed dynamically.

Middleware can be added with the new `Client#use` method.

```crystal
bot.use(MyNewMiddleware.new)
```