### PR TITLE
Add allows you to edit the message text for inline  messages

### DIFF
--- a/src/tourmaline/client/core_methods.cr
+++ b/src/tourmaline/client/core_methods.cr
@@ -198,12 +198,12 @@ module Tourmaline
         })
       end
 
-      # Use this method to edit text and game messages. On success, if
-      # edited message is sent by the bot, the edited `Message`
-      # is returned, otherwise `true` is returned.
+      # Use this method to edit text and game messages.
+      # On success, if the edited message is not an inline message,
+      # the edited Message is returned, otherwise True is returned.
       def edit_message_text(
-        chat,
         text,
+        chat = nil,
         message = nil,
         inline_message = nil,
         parse_mode = @default_parse_mode,
@@ -211,15 +211,18 @@ module Tourmaline
         disable_link_preview = false,
         reply_markup = nil
       )
-        if !message && !inline_message
-          raise "A message_id or inline_message_id is required"
+        if (!message || !chat) && !inline_message
+          raise "A message_id witth chat_id or inline_message_id is required"
         end
 
-        chat_id = chat.is_a?(Int::Primitive | String) ? chat : chat.id
-        message_id = message.is_a?(Int::Primitive | Nil) ? message : message.id
-        inline_message_id = inline_message.is_a?(Int::Primitive | Nil) ? inline_message : inline_message.id
+        if !inline_message
+          chat_id = chat.is_a?(Int::Primitive | String | Nil) ? chat : chat.id
+          message_id = message.is_a?(Int::Primitive | Nil) ? message : message.id
+        else
+          inline_message_id = inline_message.is_a?(String | Int::Primitive) ? inline_message : inline_message.id
+        end
 
-        request(Message, "editMessageText", {
+        request(Message | Bool, "editMessageText", {
           chat_id:                  chat_id,
           message_id:               message_id,
           inline_message_id:        inline_message_id,

--- a/src/tourmaline/client/core_methods.cr
+++ b/src/tourmaline/client/core_methods.cr
@@ -200,7 +200,7 @@ module Tourmaline
 
       # Use this method to edit text and game messages.
       # On success, if the edited message is not an inline message,
-      # the edited Message is returned, otherwise True is returned.
+      # the edited Message is returned, otherwise true is returned.
       def edit_message_text(
         text,
         chat = nil,
@@ -212,7 +212,7 @@ module Tourmaline
         reply_markup = nil
       )
         if (!message || !chat) && !inline_message
-          raise "A message_id witth chat_id or inline_message_id is required"
+          raise "edit_message_text requires either a chat and a message, or an inline_message"
         end
 
         if !inline_message

--- a/src/tourmaline/models/message.cr
+++ b/src/tourmaline/models/message.cr
@@ -221,7 +221,7 @@ module Tourmaline
 
     # Edits the text of a message. See `Tourmaline::Client#edit_message_text`.
     def edit_text(text, **kwargs)
-      client.edit_message_text(chat, text, **kwargs, message: message_id)
+      client.edit_message_text(text, chat, **kwargs, message: message_id)
     end
 
     # Edits the message's live_location. See `Tourmaline::Client#edit_message_live_location`


### PR DESCRIPTION
Hi Chris,
In the current version, you cannot change the text of the inline message. I fixed this and tested it on a live bot. Unfortunately, without specs, I don't see if I broke something else. If it is possible for you to accept these changes, I would be very happy, thanks anyway.

```
bot.edit_message_text(
  inline_message: active_game.not_nil!.inline_message_id,
  text: I18n.t("topic") % {first_name: user.try(&.first_name)}
)
```