### PR TITLE
Upgrade doc dependencies and update usage of mkdocs

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "astunparse": {
+            "hashes": [
+                "sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872",
+                "sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8"
+            ],
+            "markers": "python_version < '3.9'",
+            "version": "==1.6.3"
+        },
         "cached-property": {
             "hashes": [
                 "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130",
@@ -46,19 +54,19 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
-                "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
+                "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419",
+                "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==2.11.2"
+            "version": "==2.11.3"
         },
         "joblib": {
             "hashes": [
-                "sha256:75ead23f13484a2a414874779d69ade40d4fa1abe62b222a23cd50d4bc822f6f",
-                "sha256:7ad866067ac1fdec27d51c8678ea760601b70e32ff1881d4dc8e1171f2b64b24"
+                "sha256:9c17567692206d2f3fb9ecf5e991084254fe631665c450b443761c4186a613f7",
+                "sha256:feeb1ec69c4d45129954f1b7034954241eedfd6ba39b5e9e4b6883be3332d5e5"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.0.0"
+            "version": "==1.0.1"
         },
         "livereload": {
             "hashes": [
@@ -78,11 +86,11 @@
         },
         "markdown": {
             "hashes": [
-                "sha256:5d9f2b5ca24bc4c7a390d22323ca4bad200368612b5aaa7796babf971d2b2f18",
-                "sha256:c109c15b7dc20a9ac454c9e6025927d44460b85bd039da028d85e2b6d0bcc328"
+                "sha256:31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49",
+                "sha256:96c3ba1261de2f7547b46a00ea8463832c921d3f9d6aba3f255a6f71386db20c"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.3.3"
+            "version": "==3.3.4"
         },
         "markupsafe": {
             "hashes": [
@@ -91,8 +99,12 @@
                 "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
                 "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
                 "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
+                "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f",
+                "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39",
                 "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
                 "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014",
+                "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f",
                 "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
                 "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
                 "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
@@ -101,24 +113,39 @@
                 "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
                 "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
                 "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85",
+                "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1",
                 "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
                 "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
                 "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850",
+                "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0",
                 "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
                 "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb",
                 "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
                 "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
                 "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1",
+                "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2",
                 "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
                 "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
                 "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7",
                 "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8",
                 "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193",
                 "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b",
                 "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
                 "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
+                "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5",
+                "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c",
+                "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032",
                 "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
-                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
+                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be",
+                "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
@@ -139,13 +166,21 @@
             "markers": "python_version >= '3.5'",
             "version": "==1.1.2"
         },
+        "mkdocs-autorefs": {
+            "hashes": [
+                "sha256:8bed8e81db45bb8d25e30e09d9d2943a7ceb92d3ad6b51e84618027c55c398eb",
+                "sha256:ff9386ceb1ceeb88786696c7534ec31a6248a4828a5a2f8fea9d2699f650e3ab"
+            ],
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "version": "==0.1.1"
+        },
         "mkdocs-gen-files": {
             "hashes": [
-                "sha256:6284a1704d9cfb5ed834c19ee27e77d72fb21832c2a0b6b011f017f3094e5023",
-                "sha256:81357be2fbc4c09cb43c5f52a31fedaab9adf0ab155469f111aa80e04f4207d7"
+                "sha256:2ef96ae8edede9a0b83348a07e9f15d8b6c55db8ca96aac686dcb4531130cf99",
+                "sha256:7a331ca12642bad472a76a5ec342631a197383c1f7470dff5e46e0ee022fd3d7"
             ],
             "index": "pypi",
-            "version": "==0.1.0"
+            "version": "==0.3.0"
         },
         "mkdocs-literate-nav": {
             "hashes": [
@@ -172,11 +207,11 @@
         },
         "mkdocs-material": {
             "hashes": [
-                "sha256:3307d735b681f954eb1c89b64b1f4baa5a2b1a4e87a33c81244d55191c63c943",
-                "sha256:b79f1d8534e834de5823f463a036b505689a2130d68a510cdb3da70e18675e27"
+                "sha256:24db3f45ac8eca7424ecda93e1cb5a16fcd11d76932e65c9db710eb3113592b0",
+                "sha256:36b46aa1e5b47896a5a2cec129467ffcc84cf343f5296b0458a84585900cf03e"
             ],
             "index": "pypi",
-            "version": "==6.2.3"
+            "version": "==7.0.3"
         },
         "mkdocs-material-extensions": {
             "hashes": [
@@ -196,27 +231,27 @@
         },
         "mkdocs-versioning": {
             "hashes": [
-                "sha256:0b7cc97fdad31ba313ba02f1b09a7ee9bb0c52c1654302709e2e97c2c291b50e",
-                "sha256:3ccd5e9a59a98ab2e07190f2d44bbb45ce06002c9d502a50a2c3311516ee1428"
+                "sha256:2eb0053ae96ed8d897499165a66ef630dba4b8c8c0817a534e23967664a3fd63",
+                "sha256:6da04a2e7483b1800db3ff35bce86ed64b273ce886bcdf857aec46bda1f992d9"
             ],
             "index": "pypi",
-            "version": "==0.3.1"
+            "version": "==0.4.0"
         },
         "mkdocstrings": {
             "hashes": [
-                "sha256:ac821a339c53e843045d3915de208e389d48493f2612a4317cde841677bcbe48",
-                "sha256:f1b832943c4fe980fcfc17d07abfe9a8091044dbf553cb7be0ca263953130b2c"
+                "sha256:a9891420c6b9e91903a4cdf4eaf5b79dab71f3af992f7871fb43fb0f869bb26f",
+                "sha256:f1e46125c7381beccb79f213468fb4e5c4492d1c6881c06b8afbec30c737733c"
             ],
             "index": "pypi",
-            "version": "==0.14.0"
+            "version": "==0.15.0"
         },
         "mkdocstrings-crystal": {
             "hashes": [
-                "sha256:028e01fc59e74bef3a4c24b3a3aca05c0b95d4c00f770ca352256732fe966a8e",
-                "sha256:3fb3c0d3281285d158038fe9e1f0e18425dd3b4e5ac18b29f9db1ec5ee58b092"
+                "sha256:312ea22d4f29dc623d81c602fca640f86d6b35480dc4a8abaa127e6996b05551",
+                "sha256:9f0ad1bcc4713b13577224d3a0496c72254632c2bde6b2b74504836011c42fdc"
             ],
             "index": "pypi",
-            "version": "==0.2.2"
+            "version": "==0.3.1"
         },
         "nltk": {
             "hashes": [
@@ -226,27 +261,27 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858",
-                "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"
+                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
+                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.8"
+            "version": "==20.9"
         },
         "pygments": {
             "hashes": [
-                "sha256:ccf3acacf3782cbed4a989426012f1c535c9a90d3a7fc3f16d231b9372d2b716",
-                "sha256:f275b6c0909e5dafd2d6269a656aa90fa58ebf4a74f8fcf9053195d226b24a08"
+                "sha256:37a13ba168a02ac54cc5891a42b1caec333e59b66addb7fa633ea8a6d73445c0",
+                "sha256:b21b072d0ccdf29297a82a2363359d99623597b8a265b8081760e4d0f7153c88"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==2.7.3"
+            "version": "==2.8.0"
         },
         "pymdown-extensions": {
             "hashes": [
-                "sha256:565583c5964ac8253896ef4a7f14023075503ca6514d7d470b343290b96fc6da",
-                "sha256:c0b285fdd6e8438895b0c4422847af012f32a487ae083ffafa4c21a151b4983b"
+                "sha256:478b2c04513fbb2db61688d5f6e9030a92fb9be14f1f383535c43f7be9dff95b",
+                "sha256:632371fa3bf1b21a0e3f4063010da59b41db049f261f4c0b0872069a9b6d1735"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==8.1"
+            "version": "==8.1.1"
         },
         "pyparsing": {
             "hashes": [
@@ -266,29 +301,38 @@
         },
         "pytkdocs": {
             "hashes": [
-                "sha256:01fbb6f624abab5e034fffe9283ef1f36aa01702c0afae7dd29da16b3f48ce3b",
-                "sha256:f3d510063e7c2951c7b52cc860846ecbd7b21ec4b2253ae5c0084a26b233132f"
+                "sha256:8fb46adc1416fbeafebc3ea6f2adbf71efec2ff5d651a3f82801f0b6514703c2",
+                "sha256:e63ec71dc5e9feabc672f862f04394abd26557c7831c25cb8a60c99af36693b9"
             ],
             "markers": "python_version >= '3.6' and python_version < '4.0'",
-            "version": "==0.10.1"
+            "version": "==0.11.0"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
-                "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76",
-                "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2",
-                "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e",
-                "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648",
-                "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf",
-                "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f",
-                "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2",
-                "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee",
-                "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a",
-                "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d",
-                "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c",
-                "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"
             ],
-            "version": "==5.3.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==5.4.1"
         },
         "regex": {
             "hashes": [
@@ -443,11 +487,19 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:556c55b081bd9aa746d34125d024b73f0e2a0e62d5927ff0e400e20ee0a03b9a",
-                "sha256:b8b46036fd00176d0870307123ef06bb851096964fa7fc578d789f90ce82c3e4"
+                "sha256:2c44efa73b8914dba7807aefd09653ac63c22b5b4ea34f7a80973f418f1a3089",
+                "sha256:c23ac707e8e8aabb825e4d91f8e17247f9cc14b0d64dd9e97be0781e9e525bba"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==4.55.1"
+            "version": "==4.58.0"
+        },
+        "wheel": {
+            "hashes": [
+                "sha256:78b5b185f0e5763c26ca1e324373aadd49182ca90e825f7853f4b2509215dc0e",
+                "sha256:e11eefd162658ea59a60a0f6c7d493a7190ea4b9a85e335b33489d9f17e0245e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.36.2"
         }
     },
     "develop": {}

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,6 +2,7 @@
     * [Getting Started](index.md)
     * [FAQ](usage/faq.md)
     * [Asking Questions](http://www.catb.org/~esr/faqs/smart-questions.html)
+    * [Changelog](changelog.md)
     * Features
         * [Handlers](usage/features/handlers.md)
         * [Async](usage/features/async.md)
@@ -13,4 +14,6 @@
         * [Multilevel Menus](usage/features/multilevel_menus.md)
         * [Paginated Keyboards](usage/features/paginated_keyboards.md)
         * [TDLight](usage/features/tdlight.md)
-* [API Reference](api_reference/)
+* API Reference
+    * [Tourmaline](api_reference/Tourmaline/)
+    * [String](api_reference/String/)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,1 @@
+--8<-- "CHANGELOG.md"

--- a/docs/gen_doc_stubs.py
+++ b/docs/gen_doc_stubs.py
@@ -6,19 +6,11 @@ import mkdocs_gen_files
 
 root = mkdocs_gen_files.config['plugins']['mkdocstrings'].get_handler('crystal').collector.root
 
-def write_file(abs_id, filename):
-    with mkdocs_gen_files.open(filename, 'w') as f:
-        # Write the entry of a top-level alias (e.g. `AED`) on the same page as the aliased item.
-        for root_typ in root.types:
-            if root_typ.kind == "alias":
-                if root_typ.aliased == abs_id:
-                    f.write(f'::: {root_typ.abs_id}\n\n')
-
-        f.write(f'::: {abs_id}\n\n')
-
-for typ in root.lookup("Tourmaline").walk_types():
+for typ in root.walk_types():
     filename = 'api_reference/' + '/'.join(typ.abs_id.split('::')) + '/index.md'
-    write_file(typ.abs_id, filename)
 
-write_file('Tourmaline', 'api_reference/Tourmaline/index.md')
-write_file('String', 'api_reference/String.md')
+    with mkdocs_gen_files.open(filename, 'w') as f:
+        f.write(f'# ::: {typ.abs_id}\n\n')
+
+    if typ.locations:
+        mkdocs_gen_files.set_edit_path(filename, typ.locations[0].url)

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,46 +1,26 @@
-.md-typeset h4:target::before {
+.doc-method:target::before {
     display: block;
     margin-top: -4.1rem;
     padding-top: 4.1rem;
     content: "";
 }
 
-h1 {
-    margin: 0 !important;
+.doc-type > .doc-heading {
+    font-size: 1.3em !important;
 }
 
-h2.doc.doc-heading {
-    font-size: 1em !important;
-}
-
-h2.doc.doc-heading > code {
-    font-size: 1.5625em !important;
+.doc-type > .doc-heading > code {
+    font-size: 1.3em !important;
     vertical-align: baseline !important;
 }
 
-h2.doc.doc-heading > small {
-    font-size: 90% !important;
-}
-
-.doc.doc-object {
-    font-size: .85rem !important;
-}
-
-.doc-method h4 {
-    padding: 10px !important;
+.doc-method .doc-heading {
+    padding: 8px !important;
     background-color: #F8F8F8 !important;
 }
 
 .doc-source-link {
     font-size: 80%;
-}
-
-.doc-source-link::before {
-    content: "["
-}
-
-.doc-source-link::after {
-    content: "]"
 }
 
 .md-typeset dd {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ theme:
   features:
     - navigation.instant
     - navigation.tabs
+    - navigation.sections
   icon:
     logo: fontawesome/brands/telegram
     repo: fontawesome/brands/github
@@ -39,6 +40,7 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.magiclink
   - pymdownx.saneheaders
+  - pymdownx.snippets
   - pymdownx.superfences
   - pymdownx.critic
   - pymdownx.betterem:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,40 +6,43 @@
 #
 
 -i https://pypi.org/simple
+astunparse==1.6.3; python_version < '3.9'
 cached-property==1.5.2
 click==7.1.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 future==0.18.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
 glob2==0.7
-jinja2==2.11.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-joblib==1.0.0; python_version >= '3.6'
+jinja2==2.11.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+joblib==1.0.1; python_version >= '3.6'
 livereload==2.6.3
 lunr[languages]==0.5.8
-markdown==3.3.3; python_version >= '3.6'
+markdown==3.3.4; python_version >= '3.6'
 markupsafe==1.1.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 mike==0.5.5
-mkdocs-gen-files==0.1.0
+mkdocs-autorefs==0.1.1; python_version >= '3.6' and python_version < '4.0'
+mkdocs-gen-files==0.3.0
 mkdocs-literate-nav==0.3.0
 mkdocs-macros-plugin==0.5.0
 mkdocs-macros-test==0.1.0
 mkdocs-material-extensions==1.0.1; python_version >= '3.5'
-mkdocs-material==6.2.3
+mkdocs-material==7.0.3
 mkdocs-section-index==0.2.3
-mkdocs-versioning==0.3.1
+mkdocs-versioning==0.4.0
 mkdocs==1.1.2; python_version >= '3.5'
-mkdocstrings-crystal==0.2.2
-mkdocstrings==0.14.0
+mkdocstrings-crystal==0.3.1
+mkdocstrings==0.15.0
 nltk==3.5
-packaging==20.8; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-pygments==2.7.3; python_version >= '3.5'
-pymdown-extensions==8.1; python_version >= '3.6'
+packaging==20.9; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pygments==2.8.0; python_version >= '3.5'
+pymdown-extensions==8.1.1; python_version >= '3.6'
 pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
 python-dateutil==2.8.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-pytkdocs==0.10.1; python_version >= '3.6' and python_version < '4.0'
-pyyaml==5.3.1
+pytkdocs==0.11.0; python_version >= '3.6' and python_version < '4.0'
+pyyaml==5.4.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 regex==2020.11.13
 ruamel.yaml.clib==0.2.2; python_version < '3.9' and platform_python_implementation == 'CPython'
 ruamel.yaml==0.16.12
 six==1.15.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 termcolor==1.1.0
 tornado==6.1; python_version >= '3.5'
-tqdm==4.55.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+tqdm==4.58.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+wheel==0.36.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'


### PR DESCRIPTION
* Use H1 top-level headings, not H2
    * This integrates nicer with the ToC on the right, but also forces all headings to become larger
    * Some styles had to be dropped or modified due to this
* Remove some styles that mkdocstrings-crystal itself guarantees
* Simplify the type-walking script, a lot was redundant

Extras:

* Nicer nav via https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-sections
* Include the changelog into the site via https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#formatting-snippets