### PR TITLE
Add answer with game on inline query

### DIFF
--- a/src/tourmaline/models/inline/inline_query_result.cr
+++ b/src/tourmaline/models/inline/inline_query_result.cr
@@ -87,6 +87,10 @@ module Tourmaline
       def video(*args, **opts)
         results << InlineQueryResultVideo.new(*args, **opts)
       end
+
+      def game(*args, **opts)
+        results << InlineQueryResultGame.new(*args, **opts)
+      end
     end
   end
 end

--- a/src/tourmaline/models/inline/inline_query_result_game.cr
+++ b/src/tourmaline/models/inline/inline_query_result_game.cr
@@ -1,0 +1,14 @@
+module Tourmaline
+  class InlineQueryResultGame < InlineQueryResult
+    getter type : String = "game"
+
+    getter id : String
+
+    getter game_short_name : String
+
+    getter reply_markup : InlineKeyboardMarkup?
+
+    def initialize(@id : String, @game_short_name, @reply_markup = nil)
+    end
+  end
+end


### PR DESCRIPTION
Hi Chris,

subj tested on live bot and works good)

```crystal
  @[OnInlineQuery(%r{.*})]
  def process_inline_query(ctx)
    answer_inline_query(
      ctx.query.id,
      InlineQueryResult.build(&.game(ans_id(ctx), GAME_NAME)))
  end
```
```log
web          |  ▸ Handled by Bot::Webhooks::Create
web          |  ▸ Sent 200 OK (243.39µs)
web          |  ▸ sending ►► answerInlineQuery({
web          |   "inline_query_id": "1300812707560295903",
web          |   "results": "[{\"type\":\"game\",\"id\":\"e5b34962bc629635b718c73e449d46c2366386ff\",\"game_short_name\"
web          |   "cache_time": null,
web          |   "is_personal": null,
web          |   "next_offset": null,
web          |   "switch_pm_text": null,
web          |   "switch_pm_parameter": null
web          | })
web          |  ▸ Performing request
web          |  ▸ receiving ◄◄ {
web          |   "ok": true,
web          |   "result": true
web          | }
```
