### PR TITLE
Use DB::Pool to allow for retries

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -10,9 +10,8 @@ crystalline:
   main: examples/echo_bot.cr
 
 dependencies:
-  pool:
-    github: watzon/pool
-    version: 0.3.0
+  db:
+    github: crystal-lang/crystal-db
   http_proxy:
     github: mamantoha/http_proxy
     branch: master

--- a/src/tourmaline.cr
+++ b/src/tourmaline.cr
@@ -1,4 +1,3 @@
-require "pool"
 require "http_proxy"
 require "mime/multipart"
 

--- a/src/tourmaline/client/core_methods.cr
+++ b/src/tourmaline/client/core_methods.cr
@@ -1252,6 +1252,8 @@ module Tourmaline
             updates.each do |u|
               handle_update(u)
             end
+          rescue ex : Error::PoolRetryAttemptsExceeded
+            raise ex
           rescue ex
             Log.error(exception: ex) { "Error during polling" }
           end

--- a/src/tourmaline/error.cr
+++ b/src/tourmaline/error.cr
@@ -5,8 +5,9 @@ module Tourmaline
     # Raised when a connection is unable to be established
     # probably due to socket/network or configuration issues.
     # It is used by the connection pool retry logic.
-    class ConnectionLost < ::DB::PoolResourceLost(HTTP::Client)
-    end
+    class ConnectionLost < ::DB::PoolResourceLost(HTTP::Client); end
+
+    class PoolRetryAttemptsExceeded < ::DB::PoolRetryAttemptsExceeded; end
 
     ERROR_PREFIXES = ["error: ", "[error]: ", "bad request: ", "conflict: ", "not found: "]
 

--- a/src/tourmaline/error.cr
+++ b/src/tourmaline/error.cr
@@ -1,5 +1,13 @@
+require "db/pool"
+
 module Tourmaline
   class Error < Exception
+    # Raised when a connection is unable to be established
+    # probably due to socket/network or configuration issues.
+    # It is used by the connection pool retry logic.
+    class ConnectionLost < ::DB::PoolResourceLost(HTTP::Client)
+    end
+
     ERROR_PREFIXES = ["error: ", "[error]: ", "bad request: ", "conflict: ", "not found: "]
 
     def initialize(message = "")


### PR DESCRIPTION
Currently if an IO error is thrown during polling the client will only log it. If the connection needs to be rebuilt the client will simply log the error and continue to poll. Essentially making it a dead process.

The current connection pool does not handle retries but `DB::Pool` does. You can see how it is also used for a `HTTP::Client` pool in [http_client_pool_spec.cr](https://github.com/crystal-lang/crystal-db/blob/master/spec/http_client_pool_spec.cr)

This PR replaces `ConnectionPool` with `DB::Pool` and attempts a retry if a `IO::Error` or `IO::TimeoutError` is thrown. Also in the case that retry attempts are exceeded, the pool method will allow this method to be raised, ending the poll loop.

--- 

Example error thrown that will not kill polling with current connection pool.

```
Closed stream (IO::Error)
  from /usr/share/crystal/src/slice.cr:229:5 in 'write'
  from /usr/share/crystal/src/http/request.cr:109:5 in 'to_io'
  from /usr/share/crystal/src/http/client.cr:665:5 in 'exec_internal_single'
  from /usr/share/crystal/src/http/client.cr:587:5 in 'exec'
  from /usr/share/crystal/src/http/client.cr:706:5 in '->'
  from /usr/share/crystal/src/primitives.cr:255:3 in 'run'
```