### PR TITLE
Enabled handler class extension

### DIFF
--- a/src/tourmaline/event_handler.cr
+++ b/src/tourmaline/event_handler.cr
@@ -17,7 +17,7 @@ module Tourmaline
       macro register_event_handler_annotations
         {% begin %}\
           {% for method in @type.methods %}\
-            {% for event_handler in Tourmaline::EventHandler.subclasses %}\
+            {% for event_handler in Tourmaline::EventHandler.all_subclasses %}\
               {% if event_handler.has_constant?("ANNOTATION") %}\
                 {% for ann in method.annotations(event_handler.constant("ANNOTATION").resolve) %}\
                     @event_handlers << {{ event_handler.id }}.new(


### PR DESCRIPTION
This pr enables extension of existing handler classes. This is useful since sometimes you want to add a feature to an existing handler without having to reimplement the entire class. In my case i wanted to add userid based command access control, since all handlers are executed concurrently, there is no way to stop the execution flow before the method gets executed (unless there is some trick with groups). So instead of implementing my logic in every method or rewriting the entire command handler, i've extended the default one.

Example code:
```
annotation AdminCommand; end

class AdminCommandHandler < Tourmaline::CommandHandler
  ANNOTATION = AdminCommand

  def initialize(@admins : Set(Int64), *splat, **dsplat, &block : Context ->)
    super *splat, **dsplat, &block
  end

  def call(client : Tourmaline::Client, update : Tourmaline::Update)
    if message = update.message
      if issuer = message.from
        if @admins.includes? issuer.id
          return_value = super
          Log.info {
            "Executed admin commands: #{commands}"
          }
          return return_value
        else
          Log.debug {
            "Unathorized use by #{issuer.id}"
          }
        end
      end
      return true
    end
  end
end
```