### PR TITLE
stop_serving method

### DIFF
--- a/src/tourmaline/client/core_methods.cr
+++ b/src/tourmaline/client/core_methods.cr
@@ -8,6 +8,10 @@ module Tourmaline
       getter polling : Bool = false
       getter next_offset : Int64 = 0.to_i64
 
+      # Instance variable that points to the internal webhook server
+      # Should not be used outside of this class
+      @webhook_server : HTTP::Server?
+
       # Convenience method to check if this bot is an admin in
       # the current chat. See `Client#get_chat_administrators`
       # for more info.

--- a/src/tourmaline/client/webhook_methods.cr
+++ b/src/tourmaline/client/webhook_methods.cr
@@ -9,7 +9,7 @@ module Tourmaline
       #
       # Note: Don't forget to call `set_webhook` first! This method does not do it for you.
       def serve(host = "127.0.0.1", port = 8081, ssl_certificate_path = nil, ssl_key_path = nil, &block : HTTP::Server::Context ->)
-        @webhook_server = HTTP::Server.new do |context|
+        @webhook_server = server = HTTP::Server.new do |context|
           Fiber.current.telegram_bot_server_http_context = context
           begin
             block.call(context)
@@ -19,8 +19,6 @@ module Tourmaline
             Fiber.current.telegram_bot_server_http_context = nil
           end
         end
-
-        server = @webhook_server.not_nil!
 
         if ssl_certificate_path && ssl_key_path
           fl_use_ssl = true

--- a/src/tourmaline/client/webhook_methods.cr
+++ b/src/tourmaline/client/webhook_methods.cr
@@ -9,7 +9,7 @@ module Tourmaline
       #
       # Note: Don't forget to call `set_webhook` first! This method does not do it for you.
       def serve(host = "127.0.0.1", port = 8081, ssl_certificate_path = nil, ssl_key_path = nil, &block : HTTP::Server::Context ->)
-        server = HTTP::Server.new do |context|
+        @webhook_server = HTTP::Server.new do |context|
           Fiber.current.telegram_bot_server_http_context = context
           begin
             block.call(context)
@@ -19,6 +19,8 @@ module Tourmaline
             Fiber.current.telegram_bot_server_http_context = nil
           end
         end
+
+        server = @webhook_server.not_nil!
 
         if ssl_certificate_path && ssl_key_path
           fl_use_ssl = true
@@ -44,6 +46,11 @@ module Tourmaline
             handle_update(update)
           end
         end
+      end
+
+      # Stops the webhook HTTP server
+      def stop_serving
+        @webhook_server.try &.close
       end
 
       # Use this method to specify a url and receive incoming updates via an outgoing webhook.

--- a/src/tourmaline/event_handler.cr
+++ b/src/tourmaline/event_handler.cr
@@ -17,7 +17,7 @@ module Tourmaline
       macro register_event_handler_annotations
         {% begin %}\
           {% for method in @type.methods %}\
-            {% for event_handler in Tourmaline::EventHandler.subclasses %}\
+            {% for event_handler in Tourmaline::EventHandler.all_subclasses %}\
               {% if event_handler.has_constant?("ANNOTATION") %}\
                 {% for ann in method.annotations(event_handler.constant("ANNOTATION").resolve) %}\
                     @event_handlers << {{ event_handler.id }}.new(


### PR DESCRIPTION
This pull request implements the `stop_serving` method, which enables graceful halting of bots using webhooks