### PR TITLE
models/location: horizontal_accuracy is a Float64

### DIFF
--- a/src/tourmaline/models/location.cr
+++ b/src/tourmaline/models/location.cr
@@ -7,7 +7,7 @@ module Tourmaline
 
     getter latitude : Float64
 
-    getter horizontal_accuracy : Int32?
+    getter horizontal_accuracy : Float64?
 
     getter live_period : Int32?
 


### PR DESCRIPTION
this PR resolves a crash I got when (live) locations are sent in groups / to the bot:

```
2022-12-04T03:47:11.511350Z  ERROR - tourmaline.client: Error during polling
Couldn't parse (Int32 | Nil) from 7.0 at line 1, column 421
  parsing Tourmaline::Location#horizontal_accuracy at line 1, column 399
  parsing Tourmaline::Message#location at line 1, column 310
  parsing Tourmaline::Update#edited_message at line 1, column 25 (JSON::SerializableError)
  from /opt/homebrew/Cellar/crystal/1.5.0/share/crystal/src/json/serialization.cr:159:7 in 'initialize:__pull_for_json_serializable'
  from lib/tourmaline/src/tourmaline/models/update.cr:4:5 in 'new_from_json_pull_parser'
  from lib/tourmaline/src/tourmaline/models/update.cr:4:5 in 'new'
  from /opt/homebrew/Cellar/crystal/1.5.0/share/crystal/src/json/from_json.cr:209:11 in 'new'
  from /opt/homebrew/Cellar/crystal/1.5.0/share/crystal/src/json/from_json.cr:13:3 in 'from_json' 
[snip]
```

the [API docs specify `horizontal_accuracy` as a _Float_](https://core.telegram.org/bots/api#location), so I just changed the `Int32?` to a `Float64?` here