### PR TITLE
Specify using UTF-16 Little endian

### DIFF
--- a/src/tourmaline/helpers.cr
+++ b/src/tourmaline/helpers.cr
@@ -81,7 +81,7 @@ module Tourmaline
       codepoints = text.to_utf16
 
       io = IO::Memory.new
-      io.set_encoding("UTF-16")
+      io.set_encoding("UTF-16LE")
 
       codepoints.each_with_index do |codepoint, i|
         if escape && codepoint < 128


### PR DESCRIPTION
Since we're writing bytes using the LittleEndian mode, we should rather specify we're using UTF-16LE rather than let the platform randomly decide which one is the correct one.

This also fixes #60