### PR TITLE
Fixes broken cookbook link

### DIFF
--- a/src/tourmaline.cr
+++ b/src/tourmaline.cr
@@ -12,7 +12,7 @@ require "./tourmaline/client"
 #
 # For usage examples, see the
 # [examples](https://github.com/watzon/tourmaline/tree/master/examples)
-# directory. For guides on using Tourmaline, see the official
-# Tourmaline [cookbook](https://tourmaline.dev/docs/cookbook/your-first-bot).
+# directory. For guides on using Tourmaline, see the
+# [usage docs section](https://tourmaline.dev/usage/).
 module Tourmaline
 end


### PR DESCRIPTION
Hey there! 🖖 

Small nit, there is a broken link in the main Tourmaline module docs:
https://tourmaline.dev/api_reference/Tourmaline/#Tourmaline

The `cookbook` link does not exist. This pull request replaces it with a link for the usage section of the docs.